### PR TITLE
[Issue #15] Fix problems encountered in IOS platform

### DIFF
--- a/new-gui/src/components/ClickSuggestionPanel/index.js
+++ b/new-gui/src/components/ClickSuggestionPanel/index.js
@@ -417,7 +417,7 @@ const styles = StyleSheet.create({
         top: 40, 
         left: 40, 
         zIndex: 1000, 
-        width: 330, 
+        width: 300, 
         backgroundColor: 'rgba(164, 166, 164, 0.6)'
     },
     imageLabel: {

--- a/new-gui/src/components/ConfirmFoodPanel/index.js
+++ b/new-gui/src/components/ConfirmFoodPanel/index.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { withNavigation } from "react-navigation";
 import React, { Component } from "react";
 import { Button, Text, Image } from "react-native-elements";
-import { View, ScrollView, StyleSheet, Dimensions } from "react-native";
+import { View, ScrollView, StyleSheet, Dimensions, Platform } from "react-native";
 
 const FETCH_FOOD_URL = SERVER_URL + "/food-detail/fetch";
 const CONFIRM_FOOD_URL = SERVER_URL + "/food-detail/confirm";
@@ -250,7 +250,7 @@ const styles = StyleSheet.create({
     },
     foodTitle: {
         fontSize: 24, 
-        fontFamily: 'sans-serif-condensed', 
+        fontFamily: Platform.OS === 'android' ? 'sans-serif-condensed' : 'ArialMT', 
         fontWeight: 'bold',
         textAlign: 'center'
     },
@@ -260,12 +260,12 @@ const styles = StyleSheet.create({
     },
     descriptionTitle: {
         fontSize: 22,
-        fontFamily: 'sans-serif-condensed', 
+        fontFamily: Platform.OS === 'android' ? 'sans-serif-condensed' : 'ArialMT', 
         fontWeight: 'bold',
     },
     foodDescription: {
         fontSize: 20,
-        fontFamily: 'sans-serif-condensed',
+        fontFamily: Platform.OS === 'android' ? 'sans-serif-condensed' : 'ArialMT', 
         padding: 5
     },
     foodIngredientsView: {

--- a/new-gui/src/components/RecipePanel/index.js
+++ b/new-gui/src/components/RecipePanel/index.js
@@ -2,8 +2,8 @@ import { mapStateToProps, mapDispatchToProps } from "../../commons/redux";
 import { connect } from "react-redux";
 
 import React, { Component } from "react";
-import { Button, CheckBox, Input, Text, Image } from "react-native-elements";
-import { View, ScrollView, StyleSheet, Dimensions } from "react-native";
+import { Text, Image } from "react-native-elements";
+import { View, ScrollView, StyleSheet, Dimensions, Platform } from "react-native";
 
 class RecipePanel extends Component
 {
@@ -102,7 +102,7 @@ const styles = StyleSheet.create({
     },
     foodTitle: {
         fontSize: 24, 
-        fontFamily: 'sans-serif-condensed', 
+        fontFamily: Platform.OS === 'android' ? 'sans-serif-condensed' : 'ArialMT', 
         fontWeight: 'bold',
         textAlign: 'center'
     },
@@ -116,12 +116,12 @@ const styles = StyleSheet.create({
     },
     descriptionTitle: {
         fontSize: 22,
-        fontFamily: 'sans-serif-condensed', 
+        fontFamily: Platform.OS === 'android' ? 'sans-serif-condensed' : 'ArialMT', 
         fontWeight: 'bold',
     },
     foodDescription: {
         fontSize: 20,
-        fontFamily: 'sans-serif-condensed',
+        fontFamily: Platform.OS === 'android' ? 'sans-serif-condensed' : 'ArialMT', 
         padding: 5
     },
     foodIngredientsView: {

--- a/new-gui/src/components/UserInformationPanel/index.js
+++ b/new-gui/src/components/UserInformationPanel/index.js
@@ -1,15 +1,15 @@
 
 import { mapDispatchToProps, mapStateToProps } from "../../commons/redux";
 import React, { Component } from "react";
-import { KeyboardAvoidingView,Platform,StatusBar,View,SafeAreaView, Text,Alert,
-     SectionList, StyleSheet, TouchableOpacity,Image,TextInput,Dimensions,ImageBackground } from "react-native";
+import { KeyboardAvoidingView,Platform,StatusBar,View, Text,Alert,
+     SectionList, StyleSheet, TouchableOpacity,Image,TextInput } from "react-native";
 import { connect } from "react-redux";
 import { withNavigation } from "react-navigation";
 import { Ionicons } from '@expo/vector-icons';
 import { SERVER_URL } from "../../commons/serverRequest";
 import { Pedometer } from "expo";
 import Svg from 'react-native-svg';
-import { CheckBox,Input, Button } from "react-native-elements";
+import { CheckBox, Button } from "react-native-elements";
 
 const FETCH_URL  = SERVER_URL + "/user/fetch-user";
 const UPDATE_URL = SERVER_URL + "/user/update-user";
@@ -159,7 +159,7 @@ class UserInformationComponent extends Component {
             if (res.code == 0) {
                 console.warn("Error in getting user info");
             } else {
-                console.warn(res);
+                // console.warn(res);
                 this.setState({userInfo:res});
             }
         })

--- a/new-gui/src/components/UserLoginPanel/index.js
+++ b/new-gui/src/components/UserLoginPanel/index.js
@@ -82,7 +82,7 @@ class UserLoginPanel extends Component {
             })
             .then(res => res.json())
             .then(res => {
-                console.warn(res);
+                // console.warn(res);
                 if (res.code == 1) {
                     this._storeTokenData(res.token);
                     this.props.navigation.navigate("clickSuggestionPanel");

--- a/new-gui/src/components/YelpMapPanel/index.js
+++ b/new-gui/src/components/YelpMapPanel/index.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { Permissions, Location, MapView } from 'expo';
 import { mapStateToProps, mapDispatchToProps } from "../../commons/redux";
 import { connect } from "react-redux";
-import { ActivityIndicator, View, StyleSheet, Linking, Text, Image, Button } from "react-native";
+import { ActivityIndicator, View, StyleSheet, Image, Text, Platform } from "react-native";
 import axios from "axios"
 import getDirections from 'react-native-google-maps-directions';
 
@@ -140,8 +140,14 @@ class YelpMapPanel extends Component
                     coordinate={coords}
                     title={nameOfMarker}
                     description={addressOfMarker}
-                    onCalloutPress={() => this.openGoogleMap(coords)}
+                    onCalloutPress={()=> Platform.OS === 'android' ? this.openGoogleMap(coords) : null}
                 >
+                <MapView.Callout onPress={() => Platform.OS === 'ios' ? this.openGoogleMap(coords) : null}>
+                    <View>
+                        <Text style={{fontSize: 12}}>{nameOfMarker}</Text>
+                        <Text style={{fontSize: 10, color: 'grey'}}>{addressOfMarker}</Text>
+                    </View>
+                </MapView.Callout>
                 </MapView.Marker>
             )
         });


### PR DESCRIPTION
This PR introduces many fixes to the problems in the IOS platform.

1. Previously the fontFamily cannot be loaded since the fontFamily that was previously used is only for android platform
2. The label view on click suggestion panel is too wide on IOS platform, which exceeds the swipe card width.
3. Google map redirect was not working on IOS platform previously because onCalloutPress event cannot be captured by IOS platform, as mentioned in the issue https://github.com/react-native-community/react-native-maps/issues/521. The solution was to introduce our own callout and listen to the onPress event.