### PR TITLE
[Issue #18] Fix svg display issue on IOS platform

### DIFF
--- a/new-gui/src/components/UserInformationPanel/index.js
+++ b/new-gui/src/components/UserInformationPanel/index.js
@@ -272,7 +272,9 @@ class UserInformationComponent extends Component {
                     x={0}
                     y={(this.state.userInfo.caloriesNeeded-this.state.userInfo.caloriesTakenCurrently)/this.state.userInfo.caloriesNeeded*486}
                     width={300}
-                    height={this.state.userInfo.caloriesTakenCurrently/this.state.userInfo.caloriesNeeded*486}
+                    height={this.state.userInfo.caloriesTakenCurrently > 0 ? 
+                        this.state.userInfo.caloriesTakenCurrently/this.state.userInfo.caloriesNeeded*486 : 
+                        1 /this.state.userInfo.caloriesNeeded*486}
                     strokeWidth={0}
                     fill="#3CB371"
                 />


### PR DESCRIPTION
This PR introduces the fix for SVG person display issue on user panel for IOS phones. Previously if the user has not eaten anything that day, the svg height will become 0, which the person icon will disappear in the user panel.